### PR TITLE
Websphere Liberty fixes

### DIFF
--- a/websphere-liberty/Dockerfile
+++ b/websphere-liberty/Dockerfile
@@ -4,5 +4,7 @@ FROM websphere-liberty:webProfile6
 #RUN wget --directory-prefix=/opt/ibm/wlp/usr/servers/defaultServer/dropins/ $BINARY_DEPLOYMENT_ARTIFACT_URL
 COPY app/* /opt/ibm/wlp/usr/servers/defaultServer/dropins/
 
+RUN chmod a+rwx /opt/ibm/wlp/output/defaultServer
+
 # IBM WebSphere Liberty license must be accepted
 ENV LICENSE $LICENSE

--- a/websphere-liberty/websphere-liberty-template.json
+++ b/websphere-liberty/websphere-liberty-template.json
@@ -50,6 +50,16 @@
     ],
     "objects": [
         {
+            "kind": "ImageStream",
+            "apiVersion": "v1",
+            "metadata": {
+                "name": "${APPLICATION_NAME}",
+                "labels": {
+                    "application": "${APPLICATION_NAME}"
+                }
+            }
+        },
+        {
             "kind": "DeploymentConfig",
             "apiVersion": "v1",
             "metadata": {
@@ -222,16 +232,6 @@
                 },
                 "port": {
                     "targetPort": "9080-tcp"
-                }
-            }
-        },
-        {
-            "kind": "ImageStream",
-            "apiVersion": "v1",
-            "metadata": {
-                "name": "${APPLICATION_NAME}",
-                "labels": {
-                    "application": "${APPLICATION_NAME}"
                 }
             }
         }

--- a/websphere-liberty/websphere-liberty-template.json
+++ b/websphere-liberty/websphere-liberty-template.json
@@ -49,6 +49,73 @@
         }
     ],
     "objects": [
+        {
+            "kind": "DeploymentConfig",
+            "apiVersion": "v1",
+            "metadata": {
+                "name": "${APPLICATION_NAME}",
+                "labels": {
+                    "application": "${APPLICATION_NAME}"
+                }
+            },
+            "spec": {
+                "strategy": {
+                    "type": "Recreate"
+                },
+                "triggers": [
+                  {
+                      "type": "ImageChange",
+                      "imageChangeParams": {
+                        "automatic": true,
+                        "containerNames": [
+                          "${APPLICATION_NAME}"
+                        ],
+                        "from": {
+                          "kind": "ImageStreamTag",
+                          "name": "${APPLICATION_NAME}:latest"
+                        }
+                      }
+                  }
+                ],
+                "replicas": 1,
+                "selector": {
+                    "deploymentConfig": "${APPLICATION_NAME}"
+                },
+                "template": {
+                    "metadata": {
+                        "name": "${APPLICATION_NAME}",
+                        "labels": {
+                            "deploymentConfig": "${APPLICATION_NAME}",
+                            "application": "${APPLICATION_NAME}"
+                        }
+                    },
+                    "spec": {
+                        "containers": [
+                            {
+                                "name": "${APPLICATION_NAME}",
+                                "image": "${APPLICATION_NAME}",
+                                "ports": [
+                                    {
+                                        "containerPort": 9080,
+                                        "protocol": "TCP"
+                                    },
+                                    {
+                                        "containerPort": 9443,
+                                        "protocol": "TCP"
+                                    }
+                                ],
+                                "env": [
+                                    {
+                                        "name": "LICENSE",
+                                        "value": "${LICENSE}"
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                }
+            }
+        },
       {
   			"kind": "BuildConfig",
   			"apiVersion": "v1",
@@ -152,6 +219,9 @@
                 "host": "${APPLICATION_HOSTNAME}",
                 "to": {
                     "name": "${APPLICATION_NAME}"
+                },
+                "port": {
+                    "targetPort": "9080-tcp"
                 }
             }
         },
@@ -162,73 +232,6 @@
                 "name": "${APPLICATION_NAME}",
                 "labels": {
                     "application": "${APPLICATION_NAME}"
-                }
-            }
-        },
-        {
-            "kind": "DeploymentConfig",
-            "apiVersion": "v1",
-            "metadata": {
-                "name": "${APPLICATION_NAME}",
-                "labels": {
-                    "application": "${APPLICATION_NAME}"
-                }
-            },
-            "spec": {
-                "strategy": {
-                    "type": "Recreate"
-                },
-                "triggers": [
-                  {
-                      "type": "ImageChange",
-                      "imageChangeParams": {
-                        "automatic": true,
-                        "containerNames": [
-                          "${APPLICATION_NAME}"
-                        ],
-                        "from": {
-                          "kind": "ImageStreamTag",
-                          "name": "${APPLICATION_NAME}:latest"
-                        }
-                      }
-                  }
-                ],
-                "replicas": 1,
-                "selector": {
-                    "deploymentConfig": "${APPLICATION_NAME}"
-                },
-                "template": {
-                    "metadata": {
-                        "name": "${APPLICATION_NAME}",
-                        "labels": {
-                            "deploymentConfig": "${APPLICATION_NAME}",
-                            "application": "${APPLICATION_NAME}"
-                        }
-                    },
-                    "spec": {
-                        "containers": [
-                            {
-                                "name": "${APPLICATION_NAME}",
-                                "image": "${APPLICATION_NAME}",
-                                "ports": [
-                                    {
-                                        "containerPort": 9080,
-                                        "protocol": "TCP"
-                                    },
-                                    {
-                                        "containerPort": 9443,
-                                        "protocol": "TCP"
-                                    }
-                                ],
-                                "env": [
-                                    {
-                                        "name": "LICENSE",
-                                        "value": "${LICENSE}"
-                                    }
-                                ]
-                            }
-                        ]
-                    }
                 }
             }
         }

--- a/websphere-liberty/websphere-liberty-template.json
+++ b/websphere-liberty/websphere-liberty-template.json
@@ -50,16 +50,6 @@
     ],
     "objects": [
         {
-            "kind": "ImageStream",
-            "apiVersion": "v1",
-            "metadata": {
-                "name": "${APPLICATION_NAME}",
-                "labels": {
-                    "application": "${APPLICATION_NAME}"
-                }
-            }
-        },
-        {
             "kind": "DeploymentConfig",
             "apiVersion": "v1",
             "metadata": {
@@ -148,7 +138,7 @@
               "env": [
                 {
                   "name": "HTTP_PROXY",
-                  "value": "http://myproxy.net:5187/"
+                  "value": ""
                 }
               ]
     			  }
@@ -234,6 +224,16 @@
                     "targetPort": "9080-tcp"
                 }
             }
-        }
+        },
+        {
+            "kind": "ImageStream",
+            "apiVersion": "v1",
+            "metadata": {
+                "name": "${APPLICATION_NAME}",
+                "labels": {
+                    "application": "${APPLICATION_NAME}"
+                }
+            }
+        },
     ]
 }

--- a/websphere-liberty/websphere-liberty-template.json
+++ b/websphere-liberty/websphere-liberty-template.json
@@ -228,11 +228,14 @@
             "spec": {
                 "host": "${APPLICATION_HOSTNAME}",
                 "to": {
-                    "name": "${APPLICATION_NAME}"
+                    "kind": "Service",
+                    "name": "${APPLICATION_NAME}",
+                    "weight": 100
                 },
                 "port": {
                     "targetPort": "9080-tcp"
-                }
+                },
+                "wildcardPolicy": "None"
             }
         }
     ]

--- a/websphere-liberty/websphere-liberty-template.json
+++ b/websphere-liberty/websphere-liberty-template.json
@@ -27,7 +27,7 @@
         {
             "description": "URL to the source code repository hosting your WebSphere Liberty application (e.g. https://github.com/sebastianfaulhaber/openshift-v3-showcase.git)",
             "name": "SOURCE_REPOSITORY_URL",
-            "value": "https://github.com/sebastianfaulhaber/openshift-v3-showcase.git",
+            "value": "https://github.com/mglantz/openshift-v3-showcase.git",
             "required": true
         },
         {

--- a/websphere-liberty/websphere-liberty-template.json
+++ b/websphere-liberty/websphere-liberty-template.json
@@ -234,6 +234,6 @@
                     "application": "${APPLICATION_NAME}"
                 }
             }
-        },
+        }
     ]
 }


### PR DESCRIPTION
Hi there,

Here are some fixes for the template, images stream was defined after buildconfig, which caused a failure when the push to OCP registry happened. Also some permissions missing for the Docker image. Also added a targetPort for the route, which were missing. Tested and works on OCP 3.4.